### PR TITLE
Fix CI failed in GitHub Actions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -40,10 +40,10 @@ jobs:
           toolchain: stable
           override: true
           components: clippy
-      - uses: actions-rs/clippy-check@v1
+      - uses: giraffate/clippy-action@v1
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          args: --all-features --all-targets -- -D warnings
+          reporter: 'github-pr-review'
+          github_token: ${{ secrets.GITHUB_TOKEN }}
 
   test:
     name: ✅ Test Suite


### PR DESCRIPTION
This revision includes:
- Fix CI failed in GitHub Actions
  - Replace clippy with 'giraffate/clippy-action'
  - Reference: https://github.com/actions-rs/clippy-check/issues/2